### PR TITLE
Fix env var for GitHub action in MCP

### DIFF
--- a/.github/workflows/mcp_dev_deployment.yml
+++ b/.github/workflows/mcp_dev_deployment.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04
-    env:
-      AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
     strategy:
       matrix:
         python: [3.8]
@@ -22,6 +20,8 @@ jobs:
       - name: Install Tox
         run: pip install tox
       - name: Run Tox test environment
+        env:
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         # Run tox using the version of Python in `PATH`
         run: tox -e py
   dev-deployment:


### PR DESCRIPTION
Move env var to step within job rather than at job level, as it seems that the `vars` context is not available at the top level of a job.