### PR TITLE
Upgrade tooling to fix broken build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ aws_cdk_extras = [
     "constructs>=10.0.0",
 ]
 
-install_requires: list[str] = []
+install_requires: list[str] = [
+    "setuptools>=64",
+]
 
 extras_require_test = [
     *aws_cdk_extras,

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ extras = test
 envdir = toxenv
 passenv = AWS_DEFAULT_REGION
 commands =
-  pip install -e ./layers/hls_lambda_layer/python
+  pip install --use-pep517 -e ./layers/hls_lambda_layer/python
   python -m pytest --cov=lambda_functions --ignore=node_modules --ignore=cdk.out
   flake8
 
@@ -17,8 +17,8 @@ passenv =
   HLS_*
   AWS_*
 commands =
-  nodeenv --node=20.17.0 --python-virtualenv
-  npm install -g aws-cdk@v2.155.0
+  nodeenv --node=lts --python-virtualenv
+  npm install -g aws-cdk@v2.*
   cdk --version
 
 [testenv:dev]


### PR DESCRIPTION
These upgrades to our tooling should greatly reduce future build failures due to things being out of date or incompatible with each other, such as the following:

> This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version. (Cloud assembly schema version mismatch: Maximum schema version supported is 36.x.x, but found 38.0.1)

This PR does the following:

- Have tox install current LTS release of nodejs
- Have tox install latest v2.x release of CDK CLI
- Update pip editable install to work with pip 25+

The last point addresses the following warning when running tox:

> DEPRECATION: Legacy editable install of hls_lambda_layer==0.0.0 from
> file:///Users/chuck/src/NASA-IMPACT/hls-orchestration/layers/hls_lambda_layer/python
> (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour
> change. A possible replacement is to add a pyproject.toml or enable
> --use-pep517, and use setuptools >= 64. If the resulting installation
> is not behaving as expected, try using --config-settings editable_mode=compat.
> Please consult the setuptools documentation for more information.
> Discussion can be found at https://github.com/pypa/pip/issues/11457