### PR TITLE
fix: update CDK stack to support Aurora Serverless v2 

### DIFF
--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -68,8 +68,8 @@ class Rds(Construct):
             serverless_v2_min_capacity=min_capacity,
             serverless_v2_max_capacity=max_capacity,
             writer=aws_rds.ClusterInstance.serverless_v2(
-                id="instance-1",
-                instance_identifier=f"rds-{os.getenv('HLS_STACKNAME')}-instance-1",
+                id="serverless-1",
+                instance_identifier=f"rds-{os.getenv('HLS_STACKNAME')}-serverless-1",
             ),
             credentials=aws_rds.Credentials.from_password(
                 username="master",

--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -81,6 +81,18 @@ class Rds(Construct):
             removal_policy=RemovalPolicy.RETAIN,
         )
 
+        # Only set auto-pause if min_capacity is 0 as Aurora Serverless v2 doesn't
+        # support auto-pausing with >0 min capacity
+        if min_capacity == 0:
+            # CDK doesn't yet support "SecondsUntilAutoPause" but there is work in
+            # progress to add it,
+            #   issue: https://github.com/aws/aws-cdk/issues/32280
+            #   PR: https://github.com/aws/aws-cdk/pull/32787
+            self.database.node.default_child.add_property_override(
+                "ServerlessV2ScalingConfiguration.SecondsUntilAutoPause",
+                600,
+            )
+
         self.arn = self.database.cluster_arn
 
         self.policy_statement = aws_iam.PolicyStatement(

--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import aws_ec2, aws_iam, aws_rds, aws_secretsmanager
+from aws_cdk import RemovalPolicy, SecretValue, aws_ec2, aws_iam, aws_rds, aws_secretsmanager
 from constructs import Construct
 from hlsconstructs.network import Network
 
@@ -60,7 +60,7 @@ class Rds(Construct):
             self,
             "RdsCluster",
             engine=aws_rds.DatabaseClusterEngine.aurora_postgres(
-                version=aws_rds.AuroraPostgresEngineVersion.VER_13_12
+                version=aws_rds.AuroraPostgresEngineVersion.VER_13_12,
             ),
             default_database_name=self.database_name,
             enable_data_api=True,
@@ -71,18 +71,20 @@ class Rds(Construct):
                 id="instance-1",
                 instance_identifier=f"rds-{os.getenv('HLS_STACKNAME')}-instance-1",
             ),
-            credentials=aws_rds.Credentials.from_secret(
-                secret=self.secret,
+            credentials=aws_rds.Credentials.from_password(
+                username="master",
+                password=SecretValue.secrets_manager(secret_id=self.secret.secret_arn),
             ),
             vpc=network.vpc,
             subnet_group=self.subnet_group,
             security_groups=[self.security_group],
+            removal_policy=RemovalPolicy.RETAIN,
         )
 
         self.arn = self.database.cluster_arn
 
         self.policy_statement = aws_iam.PolicyStatement(
-            resources=[self.database.cluster_arn, self.secret.secret_arn],
+            resources=[self.arn, self.secret.secret_arn],
             actions=[
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:CreateSecret",

--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import Aws, Fn, aws_ec2, aws_iam, aws_rds, aws_secretsmanager
+from aws_cdk import aws_ec2, aws_iam, aws_rds, aws_secretsmanager
 from constructs import Construct
 from hlsconstructs.network import Network
 
@@ -55,56 +55,34 @@ class Rds(Construct):
             ),
         )
 
-        self.database = aws_rds.CfnDBCluster(
+        self.database_name = "hls"
+        self.database = aws_rds.DatabaseCluster(
             self,
             "RdsCluster",
-            engine="aurora-postgresql",
-            engine_mode="serverless",
-            engine_version="13.12",
-            database_name="hls",
-            db_subnet_group_name=self.subnet_group.ref,
-            enable_http_endpoint=True,
-            db_cluster_identifier=f"rds-{os.getenv('HLS_STACKNAME')}",
-            master_username=Fn.join(
-                "",
-                [
-                    "{{resolve:secretsmanager:",
-                    self.secret.secret_arn,
-                    ":SecretString:username}}",
-                ],
+            engine=aws_rds.DatabaseClusterEngine.aurora_postgres(
+                version=aws_rds.AuroraPostgresEngineVersion.VER_13_12
             ),
-            master_user_password=Fn.join(
-                "",
-                [
-                    "{{resolve:secretsmanager:",
-                    self.secret.secret_arn,
-                    ":SecretString:password}}",
-                ],
+            default_database_name=self.database_name,
+            enable_data_api=True,
+            cluster_identifier=f"rds-{os.getenv('HLS_STACKNAME')}",
+            serverless_v2_min_capacity=min_capacity,
+            serverless_v2_max_capacity=max_capacity,
+            writer=aws_rds.ClusterInstance.serverless_v2(
+                id="instance-1",
+                instance_identifier=f"rds-{os.getenv('HLS_STACKNAME')}-instance-1",
             ),
-            vpc_security_group_ids=[self.security_group.ref],
-            serverless_v2_scaling_configuration=aws_rds.CfnDBCluster.ServerlessV2ScalingConfigurationProperty(
-                max_capacity=max_capacity,
-                min_capacity=min_capacity,
-                seconds_until_auto_pause=600,
+            credentials=aws_rds.Credentials.from_secret(
+                secret=self.secret,
             ),
+            vpc=network.vpc,
+            subnet_group=self.subnet_group,
+            security_groups=[self.security_group],
         )
 
-        self.database_instance = aws_rds.CfnDBInstance(
-            self,
-            "AuroraPostgresV2Instance",
-            db_cluster_identifier=self.database.ref,
-            engine="aurora-postgresql",
-            db_instance_class="db.serverless",  # Required for Serverless v2
-        )
-
-        region = Aws.REGION
-        accountid = Aws.ACCOUNT_ID
-        self.arn = Fn.join(
-            ":", ["arn:aws:rds", region, accountid, "cluster", self.database.ref]
-        )
+        self.arn = self.database.cluster_arn
 
         self.policy_statement = aws_iam.PolicyStatement(
-            resources=[self.arn, self.secret.secret_arn],
+            resources=[self.database.cluster_arn, self.secret.secret_arn],
             actions=[
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:CreateSecret",

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -239,7 +239,7 @@ class HlsStack(Stack):
             code_file="setupdb.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=300,
@@ -345,7 +345,7 @@ class HlsStack(Stack):
             code_file="landsat_mgrs_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=120,
@@ -357,7 +357,7 @@ class HlsStack(Stack):
             code_file="landsat_mgrs_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "HISTORIC": "historic",
             },
@@ -370,7 +370,7 @@ class HlsStack(Stack):
             code_file="mgrs_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=120,
@@ -383,7 +383,7 @@ class HlsStack(Stack):
             code_file="landsat_ac_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=120,
@@ -396,7 +396,7 @@ class HlsStack(Stack):
             code_file="landsat_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=120,
@@ -408,7 +408,7 @@ class HlsStack(Stack):
             code_file="landsat_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "HISTORIC": "historic",
             },
@@ -421,7 +421,7 @@ class HlsStack(Stack):
             code_file="landsat_pathrow_status.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=120,
@@ -447,7 +447,7 @@ class HlsStack(Stack):
             code_file="sentinel_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=120,
@@ -459,7 +459,7 @@ class HlsStack(Stack):
             code_file="sentinel_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "HISTORIC": "historic",
             },
@@ -472,7 +472,7 @@ class HlsStack(Stack):
             code_file="sentinel_ac_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=800,
@@ -485,7 +485,7 @@ class HlsStack(Stack):
             code_file="sentinel_ac_logger.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=800,
@@ -505,7 +505,7 @@ class HlsStack(Stack):
             code_file="check_landsat_pathrow_complete.py",
             env={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
             },
             timeout=900,
@@ -517,7 +517,7 @@ class HlsStack(Stack):
         #  code_file="put_exit_code_cw_metric.py",
         #  env={
         #  "HLS_SECRETS": self.rds.secret.secret_arn,
-        #  "HLS_DB_NAME": self.rds.database.database_name,
+        #  "HLS_DB_NAME": self.rds.database_name,
         #  "HLS_DB_ARN": self.rds.arn,
         #  "JOB_ID": f"{STACKNAME}_landsat_ac",
         #  "TABLE_NAME": "landsat_ac_granule_log",
@@ -530,7 +530,7 @@ class HlsStack(Stack):
         #  code_file="put_exit_code_cw_metric.py",
         #  env={
         #  "HLS_SECRETS": self.rds.secret.secret_arn,
-        #  "HLS_DB_NAME": self.rds.database.database_name,
+        #  "HLS_DB_NAME": self.rds.database_name,
         #  "HLS_DB_ARN": self.rds.arn,
         #  "JOB_ID": f"{STACKNAME}_landsat_tile",
         #  "TABLE_NAME": "landsat_mgrs_granule_log",
@@ -543,7 +543,7 @@ class HlsStack(Stack):
         #  code_file="put_exit_code_cw_metric.py",
         #  env={
         #  "HLS_SECRETS": self.rds.secret.secret_arn,
-        #  "HLS_DB_NAME": self.rds.database.database_name,
+        #  "HLS_DB_NAME": self.rds.database_name,
         #  "HLS_DB_ARN": self.rds.arn,
         #  "JOB_ID": f"{STACKNAME}_sentinel",
         #  "TABLE_NAME": "sentinel_granule_log",
@@ -862,7 +862,7 @@ class HlsStack(Stack):
             cron_str=LANDSAT_INCOMPLETE_CRON,
             env_vars={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "DAYS_PRIOR": LANDSAT_DAYS_PRIOR,
                 "RETRY_LIMIT": LANDSAT_RETRY_LIMIT,
@@ -880,7 +880,7 @@ class HlsStack(Stack):
             cron_str=LANDSAT_HISTORIC_INCOMPLETE_CRON,
             env_vars={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "HOURS_PRIOR": LANDSAT_HISTORIC_HOURS_PRIOR,
                 "RETRY_LIMIT": LANDSAT_RETRY_LIMIT,
@@ -899,7 +899,7 @@ class HlsStack(Stack):
             cron_str=LANDSAT_AC_ERRORS_CRON,
             env_vars={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "RETRY_LIMIT": LANDSAT_RETRY_LIMIT,
             },
@@ -916,7 +916,7 @@ class HlsStack(Stack):
             cron_str=LANDSAT_HISTORIC_AC_ERRORS_CRON,
             env_vars={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "RETRY_LIMIT": LANDSAT_RETRY_LIMIT,
                 "HISTORIC": "historic",
@@ -933,7 +933,7 @@ class HlsStack(Stack):
             cron_str=SENTINEL_ERRORS_CRON,
             env_vars={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "RETRY_LIMIT": SENTINEL_RETRY_LIMIT,
                 "HISTORIC": "no",
@@ -950,7 +950,7 @@ class HlsStack(Stack):
             cron_str=SENTINEL_ERRORS_CRON,
             env_vars={
                 "HLS_SECRETS": self.rds.secret.secret_arn,
-                "HLS_DB_NAME": self.rds.database.database_name,
+                "HLS_DB_NAME": self.rds.database_name,
                 "HLS_DB_ARN": self.rds.arn,
                 "RETRY_LIMIT": SENTINEL_RETRY_LIMIT,
                 "HISTORIC": "historic",


### PR DESCRIPTION
## Description

This PR contains the CDK code to support our upgrade from Aurora Serverless v1 to v2 as part of AWS ceasing support for v1 as of March 31, 2025.

For the steps involved in the upgrade, see https://github.com/NASA-IMPACT/hls_development/issues/333

## How I did it

* Upgrade to use the CDK v2 construct that supports Aurora Serverless v2 - [aws_rds.DatabaseCluster](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseCluster.html)
* Define the `arn` of our `Rds` CDK construct using the ARN from the resource. We can do this now that we don't have to use a v1 level construct
* Define the `database_name` on our construct (`"hls"`) because the `DatabaseCluster` doesn't have this as a property. We need this for referencing as an environment variable in our Lambdas

## How you can test it

The `cdk diff` should come back clean with these code changes