### PR TITLE
fix: skip cleanup if we can't find anything to delete

### DIFF
--- a/lambda_functions/cleanup_sentinel2_granules.py
+++ b/lambda_functions/cleanup_sentinel2_granules.py
@@ -51,6 +51,10 @@ def handler(event: dict, context: dict):
         Prefix=prefix,
     )
 
+    if "Contents" not in response:
+        print(f"Found 0 granule zip files for prefix={prefix}, aborting.")
+        return
+
     granule_zips = [obj["Key"] for obj in response["Contents"]]
 
     # We have three possible cases,

--- a/lambda_functions/tests/test_cleanup_sentinel2_granules.py
+++ b/lambda_functions/tests/test_cleanup_sentinel2_granules.py
@@ -77,3 +77,25 @@ def test_bad_granule_id_inputs(mock_delete_object):
         handler({"granule": "thisiswronggranuleid,obviouslynotagranuleid"}, {})
         mock_list_objects.assert_not_called()
         mock_delete_object.assert_not_called()
+
+
+def test_no_granules_found_skips(mock_delete_object, capsys):
+    """Ensure we skip if no granules are found on S3
+
+    Ref: https://github.com/NASA-IMPACT/hls_development/issues/342
+    """
+    from lambda_functions.cleanup_sentinel2_granules import handler, s3
+
+    with (
+        patch.object(
+            s3,
+            "list_objects_v2",
+            return_value={},
+        ) as mock_list_objects,
+    ):
+        handler({"granule": "one12345"}, {})
+        mock_list_objects.assert_called()
+        mock_delete_object.assert_not_called()
+
+    captured = capsys.readouterr()
+    assert "Found 0 granule zip files for prefix" in captured.out


### PR DESCRIPTION
## Description

In https://github.com/NASA-IMPACT/hls_development/issues/342 we noticed that there is a race condition in our HLS pipeline where for "twin granule" conditions the "2 granule" case can finish before the "1 granule" case. When this happens the "2 granule" job has already deleted the granule inputs, causing the "1 granule" case to find 0 objects on S3. This condition isn't handled by the "cleanup" Lambda, causing it to fail. This PR adds handling for this condition