### PR TITLE
Let launch template resolve image ID via SSM Param

### DIFF
--- a/stack/hlsconstructs/batch.py
+++ b/stack/hlsconstructs/batch.py
@@ -8,7 +8,6 @@ dirname = os.path.dirname(os.path.realpath(__file__))
 
 
 class Batch(Construct):
-
     def __init__(
         self,
         scope: Construct,
@@ -17,7 +16,7 @@ class Batch(Construct):
         instance_types: list,
         maxv_cpus: int,
         ssh_keyname: str,
-        efs: aws_efs.CfnFileSystem | None = None,
+        efs: aws_efs.CfnFileSystem,
         use_cw: bool = True,
         image_id: str | None = None,
         **kwargs,

--- a/stack/hlsconstructs/batch.py
+++ b/stack/hlsconstructs/batch.py
@@ -8,6 +8,7 @@ dirname = os.path.dirname(os.path.realpath(__file__))
 
 
 class Batch(Construct):
+
     def __init__(
         self,
         scope: Construct,
@@ -16,9 +17,9 @@ class Batch(Construct):
         instance_types: list,
         maxv_cpus: int,
         ssh_keyname: str,
-        efs: aws_efs.CfnFileSystem = None,
+        efs: aws_efs.CfnFileSystem | None = None,
         use_cw: bool = True,
-        image_id=None,
+        image_id: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -120,8 +121,14 @@ class Batch(Construct):
         user_data.add_commands(user_data_string)
         user_data_str = "\n".join(user_data.render().split("\n")[1:])
 
+        if image_id is None:
+            image_id = (
+                aws_ecs.EcsOptimizedImage.amazon_linux2().get_image(self).image_id
+            )
+
         launch_template_data = aws_ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
             user_data=Fn.base64(user_data_str),
+            image_id=image_id,
             key_name=ssh_keyname,
         )
 
@@ -137,16 +144,11 @@ class Batch(Construct):
                 version=launch_template.attr_latest_version_number,
             )
         )
-        if image_id is None:
-            image_id = (
-                aws_ecs.EcsOptimizedImage.amazon_linux2().get_image(self).image_id
-            )
 
         compute_resources = aws_batch.CfnComputeEnvironment.ComputeResourcesProperty(
             #  allocation_strategy="BEST_FIT_PROGRESSIVE",
             allocation_strategy="SPOT_CAPACITY_OPTIMIZED",
             desiredv_cpus=0,
-            image_id=image_id,
             instance_role=ecs_instance_profile.ref,
             instance_types=instance_types,
             launch_template=launch_template_props,

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -128,10 +128,8 @@ class HlsStack(Stack):
 
             vpcid = os.environ["HLS_GCC_VPCID"]
             boundary_arn = os.environ["HLS_GCC_BOUNDARY_ARN"]
-            image_id = aws_ssm.StringParameter.from_string_parameter_attributes(
-                self, "gcc_ami", parameter_name="/mcp/amis/aml2-ecs"
-            ).string_value
-
+            # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-launch-template.html#use-an-ssm-parameter-instead-of-an-ami-id
+            image_id = "resolve:ssm:/mcp/amis/aml2-ecs"
             Aspects.of(self).add(PermissionBoundaryAspect(boundary_arn))
         else:
             vpcid = None


### PR DESCRIPTION
I moved the Batch image ID to the launch template, and configured it as a [parameter reference](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-launch-template.html#use-an-ssm-parameter-instead-of-an-ami-id), so that when new instances are launched, they will automatically use the current value of the `/mcp/amis/aml2-ecs` SSM Parameter.

Fixes #315