### PR TITLE
Give Batch permission to read SSM Parameters

### DIFF
--- a/stack/hlsconstructs/batch.py
+++ b/stack/hlsconstructs/batch.py
@@ -48,6 +48,9 @@ class Batch(Construct):
                 aws_iam.ManagedPolicy.from_aws_managed_policy_name(
                     "service-role/AWSBatchServiceRole"
                 ),
+                aws_iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "AmazonSSMReadOnlyAccess"
+                ),
             ],
         )
 


### PR DESCRIPTION
Now that the Batch compute environment launch template uses a reference to an SSM Parameter to get the AMI image ID, we need to give it permission to read SSM Parameters, which it did not already have.