### PR TITLE
fix: don't run yum update, prefer updates via AMI

### DIFF
--- a/stack/hlsconstructs/userdata.txt
+++ b/stack/hlsconstructs/userdata.txt
@@ -8,7 +8,6 @@ packages:
 - mdadm
 
 runcmd:
-- yum update -y --exclude="chrony*"
 - ephemeral_disks=$(realpath -P  /dev/disk/by-id/nvme*Instance_Storage* | uniq)
 - ephemeral_disks_count=$(echo "$ephemeral_disks" | wc -w)
 - scratch_fs=ext4

--- a/stack/hlsconstructs/userdata_no_cw.txt
+++ b/stack/hlsconstructs/userdata_no_cw.txt
@@ -8,7 +8,6 @@ packages:
 - mdadm
 
 runcmd:
-- yum update -y --exclude="chrony*"
 - ephemeral_disks=$(realpath -P  /dev/disk/by-id/nvme*Instance_Storage* | uniq)
 - ephemeral_disks_count=$(echo "$ephemeral_disks" | wc -w)
 - scratch_fs=ext4


### PR DESCRIPTION
## Description

This PR is attempting to resolve an issue with invalid Batch ComputeEnvironments. The ComputeEnvironments are successfully launching Ec2 instances via an Ec2 ASG, but the instances are not joining the ECS cluster backing our AWS Batch ComputeEnvironment.

This appears to have happened ~3-4 days ago, which coincides with the release of `ecs-init>=1.97` ([see release](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.97.0)). By contrast, our `hls-vi-historical-orchestration` cluster is still working and its instances are running `ecs-init==1.95.x`.

Running `yum update` will put us on the bleeding edge of packages like ecs-init, which may break our cluster if they release a breaking or buggy change.