### PR TITLE
fix: update userdata for AML2023 changes

### DIFF
--- a/stack/hlsconstructs/batch.py
+++ b/stack/hlsconstructs/batch.py
@@ -103,11 +103,11 @@ class Batch(Construct):
             cloudwatch_config_param = aws_ssm.StringParameter(
                 self,
                 "CloudWatchAgentConfigParam",
-                description="Configruation of Cloudwatch Agent for Amazon Linux 2",
+                description="Configuration of Cloudwatch Agent for Amazon Linux 2",
                 parameter_name=cloudwatch_ssm_param,
                 string_value=cloudwatch_config_string,
             )
-            # Grant ssm:GetParameters to ECS Instnace role.
+            # Grant ssm:GetParameters to ECS Instance role.
             cloudwatch_config_param.grant_read(self.ecs_instance_role)
 
             userdata_file = open(os.path.join(dirname, "userdata.txt"), "rb").read()

--- a/stack/hlsconstructs/userdata.txt
+++ b/stack/hlsconstructs/userdata.txt
@@ -46,7 +46,6 @@ cloud-init-per once create_swap
 # Mount /efs
 # https://docs.aws.amazon.com/linux/al2023/ug/efs.html
 cloud-init-per once mount_efs mount -t efs {} /mnt/efs
-mount -a
 
 --==MYBOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"

--- a/stack/hlsconstructs/userdata.txt
+++ b/stack/hlsconstructs/userdata.txt
@@ -44,7 +44,8 @@ cloud-init-per once mkdir_efs mkdir /mnt/efs
 cloud-init-per once create_swap
 
 # Mount /efs
-cloud-init-per once mount_efs echo -e '{}:/ /mnt/efs efs defaults,_netdev 0 0' >> /etc/fstab
+# https://docs.aws.amazon.com/linux/al2023/ug/efs.html
+cloud-init-per once mount_efs mount -t efs {} /mnt/efs
 mount -a
 
 --==MYBOUNDARY==

--- a/stack/hlsconstructs/userdata.txt
+++ b/stack/hlsconstructs/userdata.txt
@@ -33,18 +33,16 @@ runcmd:
 
 --==MYBOUNDARY==
 Content-Type: text/cloud-boothook; charset="us-ascii"
+#!/bin/bash -xe
 
+# ===== Mount /efs
+# See: https://docs.aws.amazon.com/linux/al2023/ug/efs.html
 # Install amazon-efs-utils
-cloud-init-per once install_amazon-efs-utils yum install -y amazon-efs-utils
+cloud-init-per once install_amazon-efs-utils dnf install -y amazon-efs-utils
 
 # Create /efs folder
 cloud-init-per once mkdir_efs mkdir /mnt/efs
-
-# Create a 16GB swapfile (128M * 128)
-cloud-init-per once create_swap
-
-# Mount /efs
-# https://docs.aws.amazon.com/linux/al2023/ug/efs.html
+# Mount
 cloud-init-per once mount_efs mount -t efs {} /mnt/efs
 
 --==MYBOUNDARY==

--- a/stack/hlsconstructs/userdata_no_cw.txt
+++ b/stack/hlsconstructs/userdata_no_cw.txt
@@ -46,7 +46,6 @@ cloud-init-per once create_swap
 # Mount /efs
 # https://docs.aws.amazon.com/linux/al2023/ug/efs.html
 cloud-init-per once mount_efs mount -t efs {} /mnt/efs
-mount -a
 
 --==MYBOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"

--- a/stack/hlsconstructs/userdata_no_cw.txt
+++ b/stack/hlsconstructs/userdata_no_cw.txt
@@ -44,7 +44,8 @@ cloud-init-per once mkdir_efs mkdir /mnt/efs
 cloud-init-per once create_swap
 
 # Mount /efs
-cloud-init-per once mount_efs echo -e '{}:/ /mnt/efs efs defaults,_netdev 0 0' >> /etc/fstab
+# https://docs.aws.amazon.com/linux/al2023/ug/efs.html
+cloud-init-per once mount_efs mount -t efs {} /mnt/efs
 mount -a
 
 --==MYBOUNDARY==

--- a/stack/hlsconstructs/userdata_no_cw.txt
+++ b/stack/hlsconstructs/userdata_no_cw.txt
@@ -33,18 +33,16 @@ runcmd:
 
 --==MYBOUNDARY==
 Content-Type: text/cloud-boothook; charset="us-ascii"
+#!/bin/bash -xe
 
+# ===== Mount /efs
+# See: https://docs.aws.amazon.com/linux/al2023/ug/efs.html
 # Install amazon-efs-utils
-cloud-init-per once install_amazon-efs-utils yum install -y amazon-efs-utils
+cloud-init-per once install_amazon-efs-utils dnf install -y amazon-efs-utils
 
 # Create /efs folder
 cloud-init-per once mkdir_efs mkdir /mnt/efs
-
-# Create a 16GB swapfile (128M * 128)
-cloud-init-per once create_swap
-
-# Mount /efs
-# https://docs.aws.amazon.com/linux/al2023/ug/efs.html
+# Mount
 cloud-init-per once mount_efs mount -t efs {} /mnt/efs
 
 --==MYBOUNDARY==


### PR DESCRIPTION
## Description

When updating from (deprecated, not available as AMI) AML2 to (supported, available as an AMI) AML2023 we noticed that the EFS mount we're using for auxiliary data was not being mounted. The instance booted up and ran our cloud init script, but failed (without logs we could find) on the section that sets up the EFS mount.

The core issue was two fold,

1. The `cloud-boothook` section did NOT have a shebang defining that it should be run with Bash.
    * I knew this was an issue because in `/var/logs/dnf.log` there was no evidence of `amazon-efs-utils` being installed in the current boot. It's apparently installed as part of the AMI creation so I found logs for that, but it's still good to ensure it's installed.
2. The `cloud-init-per once create_swap` command exited because the usage is `cloud-init-per <timing> <command name> <command ...>`. This was a usage issue that must've been upgraded to an error in the version of `cloud-init` used in AL2023

While I was at it, I made two changes for forward compatibility,

* Mount the EFS volume using these instructions for AL2023 instead of using `fstab`, https://docs.aws.amazon.com/linux/al2023/ug/efs.html
* Update to use `dnf` directly. In AL2023 they alias `yum` to `dnf`, so it's better to remove that indirection.

... 🥁 proof! I deployed this to dev from my local env, forced an Ec2 to spawn by setting minimum vCPU of compute environment to 1, and then logged in via SSM Connect to check,
<img width="827" height="231" alt="image" src="https://github.com/user-attachments/assets/77b1c4b8-765c-4f2f-8489-d9a4f2d35d1e" />
