### PR TITLE
fix: org secret added w/ newline

### DIFF
--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -33,30 +33,46 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-west-2
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install tox
         run: pip install tox
+
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      - name: Convert to environment variables
-        env:
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+
+      - name: Convert secrets and vars to environment variables
+        shell: python
         run: |
-          while read -rd $'' line
-          do
-            echo "$line" >> $GITHUB_ENV
-          done < <(jq -r <<<"$SECRETS_CONTEXT" \
-            'to_entries|map("\(.key)=\(.value)\u0000")[]')
+          import os
+
+          secrets_and_vars = {
+              **${{ toJson(secrets) }},
+              **${{ toJson(vars) }},
+          }
+
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+              for name, value in secrets_and_vars.items():
+                  # If the value contains a newline, use the delimiter syntax
+                  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+                  if "\n" in value:
+                      print(f"{name}<<EOF\n{value}\nEOF", file=env_file)
+                  else:
+                      # Standard format for single lines
+                      print(f"{name}={value}", file=env_file)
+
       - name: Deploy with tox
         run: tox -e dev -r -- deploy --require-approval never
+
       - name: Run DB setup
         env:
           HLS_STACKNAME: ${{ secrets.HLS_STACKNAME }}

--- a/.github/workflows/dev_viirs_deployment.yml
+++ b/.github/workflows/dev_viirs_deployment.yml
@@ -13,16 +13,20 @@ jobs:
       matrix:
         python: [3.9]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install Tox
         run: pip install tox
+
       - name: Run Tox test environment
         # Run tox using the version of Python in `PATH`
         run: tox -e py
+
   dev-viirs-deployment:
     strategy:
       matrix:
@@ -32,41 +36,46 @@ jobs:
     environment:
       name: dev-viirs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install tox
         run: pip install tox
+
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      - name: Convert secrets to environment variables
-        env:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SECRETS_JSON: ${{ toJson(secrets) }}
+
+      - name: Convert secrets and vars to environment variables
+        shell: python
         run: |
-          while read -rd $'' line; do
-            echo "$line" >> $GITHUB_ENV
-          done < <(
-            jq -r <<<"$SECRETS_JSON" 'to_entries|map("\(.key)=\(.value)\u0000")[]'
-          )
-      - name: Convert vars to environment variables
-        env:
-          VARS_JSON: ${{ toJson(vars) }}
-        run: |
-          while read -rd $'' line; do
-            echo "$line" >> $GITHUB_ENV
-          done < <(
-            jq -r <<<"$VARS_JSON" 'to_entries|map("\(.key)=\(.value)\u0000")[]'
-          )
+          import os
+
+          secrets_and_vars = {
+              **${{ toJson(secrets) }},
+              **${{ toJson(vars) }},
+          }
+
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+              for name, value in secrets_and_vars.items():
+                  # If the value contains a newline, use the delimiter syntax
+                  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+                  if "\n" in value:
+                      print(f"{name}<<EOF\n{value}\nEOF", file=env_file)
+                  else:
+                      # Standard format for single lines
+                      print(f"{name}={value}", file=env_file)
+
       - name: Deploy with tox
         run: tox -v -e dev -r -- deploy --require-approval never
+
       - name: Run DB setup
         run: |
           setupdb=$(aws cloudformation describe-stacks \

--- a/.github/workflows/mcp_dev_viirs_deployment.yml
+++ b/.github/workflows/mcp_dev_viirs_deployment.yml
@@ -18,16 +18,20 @@ jobs:
       matrix:
         python: [3.9]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install Tox
         run: pip install tox
+
       - name: Run Tox test environment
         # Run tox using the version of Python in `PATH`
         run: tox -e py
+
   mcp-dev-viirs-deployment:
     strategy:
       matrix:
@@ -37,39 +41,46 @@ jobs:
     environment:
       name: mcp-dev-viirs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install tox
         run: pip install tox
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_ARN }}
           role-session-name: ${{ github.actor }}
           aws-region: us-west-2
-      - name: Convert secrets to environment variables
-        env:
-          SECRETS_JSON: ${{ toJson(secrets) }}
+
+      - name: Convert secrets and vars to environment variables
+        shell: python
         run: |
-          while read -rd $'' line; do
-            echo "$line" >> $GITHUB_ENV
-          done < <(
-            jq -r <<<"$SECRETS_JSON" 'to_entries|map("\(.key)=\(.value)\u0000")[]'
-          )
-      - name: Convert vars to environment variables
-        env:
-          VARS_JSON: ${{ toJson(vars) }}
-        run: |
-          while read -rd $'' line; do
-            echo "$line" >> $GITHUB_ENV
-          done < <(
-            jq -r <<<"$VARS_JSON" 'to_entries|map("\(.key)=\(.value)\u0000")[]'
-          )
+          import os
+
+          secrets_and_vars = {
+              **${{ toJson(secrets) }},
+              **${{ toJson(vars) }},
+          }
+
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+              for name, value in secrets_and_vars.items():
+                  # If the value contains a newline, use the delimiter syntax
+                  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+                  if "\n" in value:
+                      print(f"{name}<<EOF\n{value}\nEOF", file=env_file)
+                  else:
+                      # Standard format for single lines
+                      print(f"{name}={value}", file=env_file)
+
       - name: Deploy with tox
         run: tox -v -e dev -r -- deploy --require-approval never
+
       - name: Run DB setup
         run: |
           setupdb=$(aws cloudformation describe-stacks \

--- a/.github/workflows/mcp_production_viirs_deployment.yml
+++ b/.github/workflows/mcp_production_viirs_deployment.yml
@@ -20,16 +20,20 @@ jobs:
       matrix:
         python: [3.9]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install Tox
         run: pip install tox
+
       - name: Run Tox test environment
         # Run tox using the version of Python in `PATH`
         run: tox -e py
+
   mcp-production-viirs-deployment:
     strategy:
       matrix:
@@ -39,39 +43,46 @@ jobs:
     environment:
       name: mcp-production-viirs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install tox
         run: pip install tox
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_ARN }}
           role-session-name: ${{ github.actor }}
           aws-region: us-west-2
-      - name: Convert secrets to environment variables
-        env:
-          SECRETS_JSON: ${{ toJson(secrets) }}
+
+      - name: Convert secrets and vars to environment variables
+        shell: python
         run: |
-          while read -rd $'' line; do
-            echo "$line" >> $GITHUB_ENV
-          done < <(
-            jq -r <<<"$SECRETS_JSON" 'to_entries|map("\(.key)=\(.value)\u0000")[]'
-          )
-      - name: Convert vars to environment variables
-        env:
-          VARS_JSON: ${{ toJson(vars) }}
-        run: |
-          while read -rd $'' line; do
-            echo "$line" >> $GITHUB_ENV
-          done < <(
-            jq -r <<<"$VARS_JSON" 'to_entries|map("\(.key)=\(.value)\u0000")[]'
-          )
+          import os
+
+          secrets_and_vars = {
+              **${{ toJson(secrets) }},
+              **${{ toJson(vars) }},
+          }
+
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+              for name, value in secrets_and_vars.items():
+                  # If the value contains a newline, use the delimiter syntax
+                  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+                  if "\n" in value:
+                      print(f"{name}<<EOF\n{value}\nEOF", file=env_file)
+                  else:
+                      # Standard format for single lines
+                      print(f"{name}={value}", file=env_file)
+
       - name: Deploy with tox
         run: tox -v -e dev -r -- deploy --require-approval never
+
       - name: Run DB setup
         run: |
           setupdb=$(aws cloudformation describe-stacks \

--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -12,13 +12,16 @@ jobs:
         python: [3.9]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install Tox and any other packages
         run: pip install tox
+
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
         run: tox -e py


### PR DESCRIPTION
## What I am changing

Fixes an issue dumping secrets now that there's an org level secret with a newline in it. Figured it's better to make sure we don't break if this happens versus removing the org secret, since someone can always re-add something like this.

Ref: https://github.com/NASA-IMPACT/csdap-orders/issues/624#issuecomment-3790022038

## How I did it

- Escape newline in org level secret
- Bump `checkout` and `setup-python` actions

## How you can test it

deploy workflow