### PR TITLE
fix: RDS minor version drift

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -1,3 +1,4 @@
 {
-    "app": "python3 stack/app.py"
+  "app": "python3 stack/app.py",
+  "versionReporting": false
 }

--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -56,7 +56,6 @@ class Rds(Construct):
         )
 
         self.database_name = "hls"
-
         self.database = aws_rds.DatabaseCluster(
             self,
             "RdsCluster",

--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -56,11 +56,12 @@ class Rds(Construct):
         )
 
         self.database_name = "hls"
+
         self.database = aws_rds.DatabaseCluster(
             self,
             "RdsCluster",
             engine=aws_rds.DatabaseClusterEngine.aurora_postgres(
-                version=aws_rds.AuroraPostgresEngineVersion.VER_13_12,
+                version=aws_rds.AuroraPostgresEngineVersion.of("13", "13"),
             ),
             default_database_name=self.database_name,
             enable_data_api=True,


### PR DESCRIPTION
## Description

This PR closes https://github.com/NASA-IMPACT/hls_development/issues/403

The last deployment failed because the RDS DatabaseCluster and SubnetGroup had drifted, forcing a replacement. We don't have a way of previewing and approving the CDK diff, so fortunately our IAC is setup with a specific cluster ID for the database resource. Cloudformation will refuse to orphan and replace a RDS if the instance/cluster identifier is the same because it knows the operation will fail. This refusal (ty CDK 🙏)

I suspect the root cause of the drift is,
1. We specified a specific minor version of the `AuroraPostgresEngineVersion` while allowing minor version auto-upgrades
2. AWS auto-upgraded the minor version for us over time until we hit 13.20, causing drift in our stack
3. ❓ perhaps related, the subnet group name dropped from the stack definition, thus becoming drift ❓

## What I did

To resolve the deployment failure,

1. I specified a relaxed version to any minor version of `13` in CDK code. I did this via `AuroraPostgresEngineVersion.of("13", "13")` because unfortunately there's no major-version-only enum variant (like there is with PostgresEngineVersion)
2. I updated our CDK config to disable analytics. The motivation was to make CDK import operations easier
    - For example:
        - When analytics are disabled the Cloudformation template file has a `CDKMetadata` section with the tracking information (see https://docs.aws.amazon.com/cdk/v2/guide/usage-data.html#usage-data-how)
        - I can't regenerate the exact tracking info as exists from a CI/CD deployment locally
        - My `cdk diff` doesn't show `CDKMetadata`, so I think that my stack diff is only the resources to import
        - I try to upload the CDK template into the Cloudformation "Import resources" UI, but fail because there is a diff in `CDKMetadata` and I can't force the UI to ignore resources changing that aren't being imported.
        - To resolve this I have to copy the analytics from the Cloudformation template locally so my CDK template won't have an unexpected diff.
3. I did the "CDK orphan and re-import" hokey pokey and reimported the RDS cluster/instances into the development and production stacks.

## How you can test

Clean `cdk diff`s (caveat: you got all the environment variables consistent with Github)
