### PR TITLE
chore: bump py3.9 to py3.13

### DIFF
--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -10,7 +10,7 @@ jobs:
       AWS_DEFAULT_REGION: us-west-2
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -25,7 +25,7 @@ jobs:
   dev-deployment:
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     runs-on: ubuntu-latest
     needs: [unit-tests]
     environment:

--- a/.github/workflows/dev_viirs_deployment.yml
+++ b/.github/workflows/dev_viirs_deployment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     steps:
       - uses: actions/checkout@v6
 
@@ -30,7 +30,7 @@ jobs:
   dev-viirs-deployment:
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     runs-on: ubuntu-latest
     needs: [unit-tests]
     environment:

--- a/.github/workflows/mcp_dev_viirs_deployment.yml
+++ b/.github/workflows/mcp_dev_viirs_deployment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     steps:
       - uses: actions/checkout@v6
 
@@ -35,7 +35,7 @@ jobs:
   mcp-dev-viirs-deployment:
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     runs-on: ubuntu-latest
     needs: [unit-tests]
     environment:

--- a/.github/workflows/mcp_production_viirs_deployment.yml
+++ b/.github/workflows/mcp_production_viirs_deployment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     steps:
       - uses: actions/checkout@v6
 
@@ -37,7 +37,7 @@ jobs:
   mcp-production-viirs-deployment:
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
     runs-on: ubuntu-latest
     needs: [unit-tests]
     environment:

--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.13]
 
     steps:
       - uses: actions/checkout@v6

--- a/stack/hlsconstructs/efs.py
+++ b/stack/hlsconstructs/efs.py
@@ -35,7 +35,7 @@ class Efs(Construct):
         for subnet in network.vpc.select_subnets(one_per_az=True).subnets:
             mount_target = aws_efs.CfnMountTarget(
                 self,
-                f"MountTarget{len(mount_targets)+1}",
+                f"MountTarget{len(mount_targets) + 1}",
                 file_system_id=self.filesystem.ref,
                 security_groups=[self.mount_target_security_group.ref],
                 subnet_id=subnet.subnet_id,

--- a/stack/hlsconstructs/lambdafunc.py
+++ b/stack/hlsconstructs/lambdafunc.py
@@ -27,7 +27,7 @@ class Lambda(Construct):
         code_str: str = None,
         package_code_dir: str = None,
         env: Dict = None,
-        runtime: aws_lambda.Runtime = aws_lambda.Runtime.PYTHON_3_9,
+        runtime: aws_lambda.Runtime = aws_lambda.Runtime.PYTHON_3_13,
         handler: str = "index.handler",
         layers: list = None,
         cron_str: str = None,

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -306,7 +306,7 @@ class HlsStack(Stack):
                     os.path.dirname(__file__), "..", "layers", "hls_lambda_layer"
                 )
             ),
-            compatible_runtimes=[aws_lambda.Runtime.PYTHON_3_9],
+            compatible_runtimes=[aws_lambda.Runtime.PYTHON_3_13],
         )
 
         self.pr2mgrs_lambda = Lambda(


### PR DESCRIPTION
## Description

This PR addresses AWS's deprecation of Lambda 3.9 runtime (and the corresponding MCP ticket) by bumping to 3.13.