### PR TITLE
feat: metrics log group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,9 +24,10 @@ Setting `HLS_METRIC_LOG_GROUP_NAME` without enabling `HLS_INSTRUMENT_SCIENCE_CON
 ensures the log group exists before instrumentation is turned on, so there is no "log group already exists" conflict
 when toggling.
 
-The log stream for each job is the `AWS_BATCH_JOB_ID`. The log group and stream must exist before metrics can be emitted
-— the science container will not create them. The log group is managed by the CDK stack with a 90-day retention policy
-and `RemovalPolicy.RETAIN` (it will not be deleted on stack teardown).
+The log stream for each job is the `AWS_BATCH_JOB_ID`. The log group must exist before metrics can be emitted — the
+science container will create the log stream automatically on startup (and silently reuse it if it already exists). The
+log group is managed by the CDK stack with a 90-day retention policy and `RemovalPolicy.RETAIN` (it will not be deleted
+on stack teardown).
 
 ### Experiment Dimensions
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,86 @@
+## Task Metrics
+
+The HLS science container supports optional per-task metrics collection for Batch jobs running the Sentinel-2 (S30),
+Landsat AC (L30-AC), and Landsat Tile (L30-Tile) workflows. When enabled, each instrumented task emits a structured log
+event in
+[CloudWatch Embedded Metrics Format (EMF)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html)
+at the end of its execution. CloudWatch Logs Insights can query the raw log lines, while CloudWatch Metrics
+automatically extracts the numeric values for dashboards and alarms.
+
+The primary use case is performance comparison across code or configuration changes — for example, measuring the
+wall-clock time and peak memory of Fmask v4 vs. v5 side-by-side using experiment dimensions.
+
+### Enabling Metrics
+
+Two environment variables control metrics. Set them in the GitHub environment for your deployment target (or in
+`environment.sh` locally) before running `cdk deploy`.
+
+| Variable                           | Required              | Description                                                                                                                                                            |
+| ---------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HLS_METRIC_LOG_GROUP_NAME`        | Yes                   | Name of the CloudWatch Logs log group (e.g. `/hls/nextgen/metrics`). The log group is always created by the CDK stack regardless of whether instrumentation is active. |
+| `HLS_INSTRUMENT_SCIENCE_CONTAINER` | No (default: `false`) | Set to `true` to forward `METRIC_LOG_GROUP_NAME` to containers and grant `logs:PutLogEvents` to Batch task roles.                                                      |
+
+Setting `HLS_METRIC_LOG_GROUP_NAME` without enabling `HLS_INSTRUMENT_SCIENCE_CONTAINER` is safe and intentional: it
+ensures the log group exists before instrumentation is turned on, so there is no "log group already exists" conflict
+when toggling.
+
+The log stream for each job is the `AWS_BATCH_JOB_ID`. The log group and stream must exist before metrics can be emitted
+— the science container will not create them. The log group is managed by the CDK stack with a 90-day retention policy
+and `RemovalPolicy.RETAIN` (it will not be deleted on stack teardown).
+
+### Experiment Dimensions
+
+Any environment variable prefixed with `HLS_EXPERIMENT_` in the GitHub environment is baked into the Batch JobDefinition
+and forwarded to the container when `HLS_INSTRUMENT_SCIENCE_CONTAINER=true`. The prefix is stripped to form the
+CloudWatch dimension name:
+
+```
+HLS_EXPERIMENT_FMASK_VERSION=v5   →   dimension: fmask_version=v5
+HLS_EXPERIMENT_LASRC_VERSION=2.1  →   dimension: lasrc_version=3.5.8
+```
+
+These dimensions appear on every metric emitted during the job, making it straightforward to filter or compare in
+CloudWatch Metrics and Logs Insights.
+
+### Metrics Collected
+
+Three metrics are captured per instrumented task execution:
+
+| Metric            | Unit      | Description                                                |
+| ----------------- | --------- | ---------------------------------------------------------- |
+| `runtime_seconds` | Seconds   | Wall-clock time from task start to finish                  |
+| `peak_memory_mb`  | Megabytes | Peak RSS across the Python process and all child processes |
+| `max_cpu_percent` | Percent   | Maximum combined CPU utilisation across the process tree   |
+
+Memory and CPU are sampled at 1-second intervals in a background polling thread, covering both Python-level work and any
+subprocesses (e.g. the LaSRC or Fmask executables).
+
+### Instrumented Tasks
+
+Not every task is instrumented — only the computationally significant ones opt in. This also only works with the
+"nextgen" `hls-science-container` that updates the within-container orchestration.
+
+| Workflow | Task                                 |
+| -------- | ------------------------------------ |
+| S30      | `RunFmask`, `RunFmaskV5`, `RunLaSRC` |
+| L30-AC   | `RunFmask`, `RunFmaskV5`, `RunLaSRC` |
+| L30-Tile | `ProcessPathRows`, `RunNbar`         |
+
+### Querying Metrics
+
+**CloudWatch Logs Insights** — raw EMF records are queryable as structured JSON:
+
+```
+fields @timestamp, task_name, runtime_seconds, peak_memory_mb, fmask_version
+| filter ispresent(fmask_version)
+| sort @timestamp desc
+```
+
+**CloudWatch Metrics** — EMF records are auto-extracted into the `HLS/Tasks` namespace with the following dimensions per
+record:
+
+- `task_class` — Python class name of the task
+- `task_name` — instance name assigned in the workflow
+- `job_id` — `AWS_BATCH_JOB_ID`
+- `granule_id` — set for per-granule mapped tasks (S30 and L30-AC)
+- Any `HLS_EXPERIMENT_*` dimensions defined at deploy time

--- a/environment.sh.sample
+++ b/environment.sh.sample
@@ -17,6 +17,9 @@ set -a
 # LAADS DAAC Token
 HLS_LAADS_TOKEN="<your token>"
 
+# CloudWatch Logs log group for per-task EMF metrics
+HLS_METRIC_LOG_GROUP_NAME=/hls/nextgen/metrics
+
 # Bucket used for processing output
 HLS_OUTPUT_BUCKET=hls-global
 HLS_OUTPUT_BUCKET_HISTORIC=hls-gobal-historic
@@ -87,6 +90,15 @@ HLS_GCC_VPCID=vpcid
 HLS_GCC_BOUNDARY_ARN=boudary_policy_arn
 # Use Cloudwatch metrics for containers
 # HLS_USE_CLOUD_WATCH=true
+
+# Set to true to forward METRIC_LOG_GROUP_NAME to science containers and grant logs:PutLogEvents
+# HLS_INSTRUMENT_SCIENCE_CONTAINER=true
+
+# Experiment dimensions baked into container metrics when instrumentation is enabled.
+# Any number of HLS_EXPERIMENT_* variables can be defined; the prefix is stripped to form the
+# CloudWatch dimension name (e.g. HLS_EXPERIMENT_FMASK_VERSION=v5 → dimension fmask_version=v5).
+# HLS_EXPERIMENT_FMASK_VERSION=v5
+# HLS_EXPERIMENT_LASRC_VERSION=2.1
 
 # end of allexport mode
 set +a

--- a/stack/hlsconstructs/docker_batchjob.py
+++ b/stack/hlsconstructs/docker_batchjob.py
@@ -17,6 +17,7 @@ class DockerBatchJob(Construct):
         memory: int = 10000,
         vcpus: int = 4,
         mountpath: str = "/efs",
+        environment: dict[str, str] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -66,6 +67,10 @@ class DockerBatchJob(Construct):
             container_path="/var/scratch",
             read_only=False,
         )
+        env_props = [
+            aws_batch.CfnJobDefinition.KeyValuePairProperty(name=k, value=v)
+            for k, v in (environment or {}).items()
+        ]
         container_properties = aws_batch.CfnJobDefinition.ContainerPropertiesProperty(
             image=image_uri,
             job_role_arn=self.role.role_arn,
@@ -73,6 +78,7 @@ class DockerBatchJob(Construct):
             mount_points=[mount_point, scratch_mount_point],
             vcpus=vcpus,
             volumes=[volume, scratch_volume],
+            environment=env_props or None,
         )
 
         job = aws_batch.CfnJobDefinition(

--- a/stack/hlsconstructs/docker_batchjob.py
+++ b/stack/hlsconstructs/docker_batchjob.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import aws_batch, aws_ecr_assets, aws_ecs, aws_iam, aws_s3
+from aws_cdk import Stack, aws_batch, aws_ecr_assets, aws_ecs, aws_iam, aws_s3
 from constructs import Construct
 
 dirname = os.path.dirname(os.path.realpath(__file__))
@@ -67,9 +67,11 @@ class DockerBatchJob(Construct):
             container_path="/var/scratch",
             read_only=False,
         )
+
+        env_vars = {"AWS_DEFAULT_REGION": Stack.of(self).region, **(environment or {})}
         env_props = [
             aws_batch.CfnJobDefinition.EnvironmentProperty(name=k, value=v)
-            for k, v in (environment or {}).items()
+            for k, v in env_vars.items()
         ]
         container_properties = aws_batch.CfnJobDefinition.ContainerPropertiesProperty(
             image=image_uri,
@@ -78,7 +80,7 @@ class DockerBatchJob(Construct):
             mount_points=[mount_point, scratch_mount_point],
             vcpus=vcpus,
             volumes=[volume, scratch_volume],
-            environment=env_props or None,
+            environment=env_props,
         )
 
         job = aws_batch.CfnJobDefinition(

--- a/stack/hlsconstructs/docker_batchjob.py
+++ b/stack/hlsconstructs/docker_batchjob.py
@@ -5,6 +5,8 @@ from constructs import Construct
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 
+_CONTAINER_ENV_PREFIX = "HLS_CONTAINER_"
+
 
 class DockerBatchJob(Construct):
     def __init__(
@@ -68,7 +70,16 @@ class DockerBatchJob(Construct):
             read_only=False,
         )
 
-        env_vars = {"AWS_DEFAULT_REGION": Stack.of(self).region, **(environment or {})}
+        forwarded = {
+            k.removeprefix(_CONTAINER_ENV_PREFIX): v
+            for k, v in os.environ.items()
+            if k.startswith(_CONTAINER_ENV_PREFIX)
+        }
+        env_vars = {
+            "AWS_DEFAULT_REGION": Stack.of(self).region,
+            **forwarded,
+            **(environment or {}),
+        }
         env_props = [
             aws_batch.CfnJobDefinition.EnvironmentProperty(name=k, value=v)
             for k, v in env_vars.items()

--- a/stack/hlsconstructs/docker_batchjob.py
+++ b/stack/hlsconstructs/docker_batchjob.py
@@ -68,7 +68,7 @@ class DockerBatchJob(Construct):
             read_only=False,
         )
         env_props = [
-            aws_batch.CfnJobDefinition.KeyValuePairProperty(name=k, value=v)
+            aws_batch.CfnJobDefinition.EnvironmentProperty(name=k, value=v)
             for k, v in (environment or {}).items()
         ]
         container_properties = aws_batch.CfnJobDefinition.ContainerPropertiesProperty(

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -8,6 +8,7 @@ from aws_cdk import (
     Stack,
     aws_iam,
     aws_lambda,
+    aws_logs,
     aws_s3,
     aws_sns,
     aws_ssm,
@@ -42,6 +43,7 @@ OUTPUT_BUCKET_HISTORIC = os.environ["HLS_OUTPUT_BUCKET_HISTORIC"]
 GIBS_OUTPUT_BUCKET = os.environ["HLS_GIBS_OUTPUT_BUCKET"]
 GIBS_OUTPUT_BUCKET_HISTORIC = os.environ["HLS_GIBS_OUTPUT_BUCKET_HISTORIC"]
 LANDSAT_HISTORIC_SNS_TOPIC = os.environ["HLS_LANDASAT_HISTORIC_SNS_TOPIC"]
+METRIC_LOG_GROUP_NAME = os.environ["HLS_METRIC_LOG_GROUP_NAME"]
 
 
 def getenv(key, default):
@@ -117,6 +119,12 @@ except ValueError:
 REPLACE_EXISTING = getenv("HLS_REPLACE_EXISTING", "true") == "true"
 USE_CLOUD_WATCH = getenv("HLS_USE_CLOUD_WATCH", "false") == "true"
 GCC = getenv("GCC", None) == "true"
+INSTRUMENT_SCIENCE_CONTAINER = (
+    getenv("HLS_INSTRUMENT_SCIENCE_CONTAINER", "false") == "true"
+)
+EXPERIMENT_ENV = {
+    k: v for k, v in os.environ.items() if k.startswith("HLS_EXPERIMENT_")
+}
 
 
 class HlsStack(Stack):
@@ -140,6 +148,14 @@ class HlsStack(Stack):
             image_id = None
 
         self.network = Network(self, "Network", vpcid=vpcid)
+
+        self.metrics_log_group = aws_logs.LogGroup(
+            self,
+            "MetricsLogGroup",
+            log_group_name=METRIC_LOG_GROUP_NAME,
+            retention=aws_logs.RetentionDays.THREE_MONTHS,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
 
         self.laads_bucket = S3(self, "LaadsBucket", bucket_name=LAADS_BUCKET)
 
@@ -269,6 +285,10 @@ class HlsStack(Stack):
             vcpus=2,
         )
 
+        task_env = None
+        if INSTRUMENT_SCIENCE_CONTAINER:
+            task_env = {"METRIC_LOG_GROUP_NAME": METRIC_LOG_GROUP_NAME, **EXPERIMENT_ENV}
+
         self.sentinel_task = DockerBatchJob(
             self,
             "SentinelTask",
@@ -277,6 +297,7 @@ class HlsStack(Stack):
             timeout=7200,
             memory=20000,
             vcpus=2,
+            environment=task_env,
         )
 
         self.landsat_task = DockerBatchJob(
@@ -287,6 +308,7 @@ class HlsStack(Stack):
             timeout=5400,
             memory=20000,
             vcpus=2,
+            environment=task_env,
         )
 
         self.landsat_tile_task = DockerBatchJob(
@@ -296,7 +318,17 @@ class HlsStack(Stack):
             timeout=5400,
             memory=16000,
             vcpus=2,
+            environment=task_env,
         )
+
+        if INSTRUMENT_SCIENCE_CONTAINER:
+            for task in [self.sentinel_task, self.landsat_task, self.landsat_tile_task]:
+                task.role.add_to_policy(
+                    aws_iam.PolicyStatement(
+                        actions=["logs:PutLogEvents"],
+                        resources=[f"{self.metrics_log_group.log_group_arn}:*"],
+                    )
+                )
 
         self.hls_lambda_layer = aws_lambda.LayerVersion(
             self,

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -167,6 +167,18 @@ class HlsStack(Stack):
             self, "landsat_output_bucket", OUTPUT_BUCKET
         )
 
+        self.output_bucket_historic = aws_s3.Bucket.from_bucket_name(
+            self, "output_bucket_historic", OUTPUT_BUCKET_HISTORIC
+        )
+
+        self.gibs_output_bucket = aws_s3.Bucket.from_bucket_name(
+            self, "gibs_output_bucket", GIBS_OUTPUT_BUCKET
+        )
+
+        self.gibs_output_bucket_historic = aws_s3.Bucket.from_bucket_name(
+            self, "gibs_output_bucket_historic", GIBS_OUTPUT_BUCKET_HISTORIC
+        )
+
         sentinel_input_bucket_expiration_days = int(
             os.environ["HLS_SENTINEL_INPUT_BUCKET_EXPIRATION_DAYS"]
         )
@@ -1175,6 +1187,31 @@ class HlsStack(Stack):
                     "s3:Get*",
                     "s3:List*",
                 ],
+            )
+        )
+        # Direct output bucket access for new job definitions (task role credentials).
+        # Old job definitions continue to use the instance role + GCC_ROLE_ARN path below.
+        _output_bucket_resources = [
+            self.sentinel_output_bucket.bucket_arn,
+            f"{self.sentinel_output_bucket.bucket_arn}/*",
+            self.output_bucket_historic.bucket_arn,
+            f"{self.output_bucket_historic.bucket_arn}/*",
+            self.gibs_output_bucket.bucket_arn,
+            f"{self.gibs_output_bucket.bucket_arn}/*",
+            self.gibs_output_bucket_historic.bucket_arn,
+            f"{self.gibs_output_bucket_historic.bucket_arn}/*",
+        ]
+        _output_bucket_actions = ["s3:Get*", "s3:Put*", "s3:List*", "s3:AbortMultipartUpload"]
+        self.sentinel_task.role.add_to_policy(
+            aws_iam.PolicyStatement(
+                resources=_output_bucket_resources,
+                actions=_output_bucket_actions,
+            )
+        )
+        self.landsat_tile_task.role.add_to_policy(
+            aws_iam.PolicyStatement(
+                resources=_output_bucket_resources,
+                actions=_output_bucket_actions,
             )
         )
         # Cross account role assumption for GCC bucket

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -325,7 +325,7 @@ class HlsStack(Stack):
             for task in [self.sentinel_task, self.landsat_task, self.landsat_tile_task]:
                 task.role.add_to_policy(
                     aws_iam.PolicyStatement(
-                        actions=["logs:PutLogEvents"],
+                        actions=["logs:CreateLogStream", "logs:PutLogEvents"],
                         resources=[f"{self.metrics_log_group.log_group_arn}:*"],
                     )
                 )


### PR DESCRIPTION
## Description

>[!NOTE]
>This PR compliments/enables https://github.com/NASA-IMPACT/hls-science-container/pull/19

We want to be able to monitor the resource consumption and runtime of individual preprocessing steps we run within our monolithic "HLS science algorithms" container (used by Sentinel-2 AC, Landsat AC, and Landsat Tile workflows). This is especially important to understand whether or not changes to algorithms will cause changes in the computational performance ($ and reliability). For example, we want to evaluate if Fmask v5 is slower than v4 or how the anticipated changes to LaSRC reduce the runtime.

## How I did it

This PR,

- Deploys a new metrics-specific log group
- Expects an envvar, `INSTRUMENT_SCIENCE_CONTAINER` ("false" or "true"), that toggles whether or not we tell the container to log metric.
- Looks for `HLS_EXPERIMENT_` envvars we add via Github environment and populates them into the container. These will be used as dimensions for the metrics we log.
- Adds IAM permission to our job if `INSTRUMENT_SCIENCE_CONTAINER=true`

As a side change, I am adding permissions for our Landsat Tiling and Sentinel-2 AC jobs to write to the output buckets WITHOUT having to assume the "GCC cross account" role.