### PR TITLE
feat: laads outage slack alert

### DIFF
--- a/lambda_functions/laads_alert.py
+++ b/lambda_functions/laads_alert.py
@@ -1,0 +1,209 @@
+"""
+HLS: LAADS Availability Alert
+
+Scheduled Lambda that checks whether LAADS auxiliary data is available in S3
+for the recent past (configurable lookback window, default 14 days). Sends a
+Slack alert when data is missing and a recovery alert when data reappears after
+an outage. State is persisted in SSM Parameter Store to enable recovery detection
+and alert throttling.
+
+The check can run frequently (e.g. every 30 minutes) but "missing" alerts are
+throttled to at most once every LAADS_ALERT_INTERVAL_HOURS hours. Recovery
+alerts fire immediately regardless of the throttle.
+
+Environment variables:
+  LAADS_BUCKET                - S3 bucket containing LAADS auxiliary data
+  HLS_SLACK_ALERT_WEBHOOK     - Slack incoming webhook URL (optional; skips alerting if unset)
+  LAADS_ALERT_STATE_SSM_PATH  - SSM parameter path for persisting outage state
+  LAADS_LOOKBACK_DAYS         - Number of days back to check (default: 14)
+  LAADS_ALERT_INTERVAL_HOURS  - Min hours between repeated "missing" alerts (default: 12)
+  LAADS_LAG_HOURS             - Expected publication lag in hours (default: 30 = 24h lag + 6h
+                                buffer). The most recent date checked is today minus this lag,
+                                so we don't false-alert on data that simply hasn't been published
+                                yet.
+"""
+
+import dataclasses
+import json
+import os
+import urllib.request
+from dataclasses import dataclass, field
+import datetime as dt
+from typing import Literal
+
+import boto3
+from botocore.exceptions import ClientError
+
+from hls_lambda_layer.laads_utils import check_laads_for_date
+
+ssm = boto3.client("ssm")
+
+
+@dataclass
+class AlertState:
+    status: Literal["available", "missing"] = "available"
+    last_alert_sent: dt.datetime | None = None  # UTC datetime of last Slack post
+    missing_since: str | None = (
+        None  # yyyy-mm-dd of first missing day in current outage
+    )
+    missing_days: list[str] = field(default_factory=list)  # yyyy-mm-dd, newest-first
+
+
+def _get_state(ssm_path: str) -> AlertState:
+    """Read alert state from SSM. Returns a default AlertState if the parameter doesn't exist yet."""
+    try:
+        response = ssm.get_parameter(Name=ssm_path, WithDecryption=False)
+        data = json.loads(response["Parameter"]["Value"])
+        if data.get("last_alert_sent"):
+            data["last_alert_sent"] = dt.datetime.fromisoformat(data["last_alert_sent"])
+        return AlertState(**data)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ParameterNotFound":
+            return AlertState()
+        raise
+
+
+def _put_state(ssm_path: str, state: AlertState) -> None:
+    """Persist alert state to SSM."""
+
+    def _serialize(obj):
+        if isinstance(obj, dt.datetime):
+            return obj.isoformat()
+        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+    ssm.put_parameter(
+        Name=ssm_path,
+        Value=json.dumps(dataclasses.asdict(state), default=_serialize),
+        Type="String",
+        Overwrite=True,
+    )
+
+
+def _post_slack(webhook_url: str, message: str) -> None:
+    """Send a plain text message to a Slack incoming webhook."""
+    payload = json.dumps({"text": message}).encode("utf-8")
+    req = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        print(f"Slack response: {resp.status}")
+
+
+def _check_recent_availability(
+    bucket: str, lookback: dt.timedelta, lag: dt.timedelta
+) -> list[str]:
+    """Check LAADS availability for the past lookback period, accounting for
+    the provider's publication lag.
+
+    The most recent date checked is (now - lag), so we don't false-alert on
+    data that simply hasn't been published yet (LAADS publishes with ~24h lag).
+
+    Returns a list of date strings (yyyy-mm-dd) for which data is missing,
+    ordered newest-first.
+    """
+    anchor = (dt.datetime.now(tz=dt.timezone.utc) - lag).date()
+    missing = []
+    for offset in range(lookback.days):
+        check_date = anchor - dt.timedelta(days=offset)
+        date_str = check_date.strftime("%Y-%m-%d")
+        available, _ = check_laads_for_date(bucket, date_str)
+        if not available:
+            missing.append(date_str)
+    return missing
+
+
+def _alert_due(state: AlertState, alert_interval: dt.timedelta) -> bool:
+    """Return True if enough time has passed since the last "missing" alert."""
+    if state.last_alert_sent is None:
+        return True
+    return dt.datetime.now(tz=dt.timezone.utc) - state.last_alert_sent >= alert_interval
+
+
+def _handle_outage(
+    state: AlertState,
+    missing_days: list[str],
+    lookback: dt.timedelta,
+    alert_interval: dt.timedelta,
+    now: dt.datetime,
+    webhook_url: str | None,
+) -> tuple[AlertState, bool]:
+    new_state = AlertState(
+        status="missing",
+        missing_since=state.missing_since or missing_days[0],
+        missing_days=missing_days,
+        last_alert_sent=state.last_alert_sent,
+    )
+    if not _alert_due(state, alert_interval):
+        print(
+            f"LAADS data still missing but alert throttled (last sent: {state.last_alert_sent})."
+        )
+        return new_state, False
+
+    earliest_missing = missing_days[-1]  # list is newest-first
+    latest_missing = missing_days[0]
+    message = (
+        f":warning: LAADS data is missing for {len(missing_days)} day(s) "
+        f"within the past {lookback.days} days. "
+        f"Earliest missing: {earliest_missing}, most recent missing: {latest_missing}."
+    )
+    print(message)
+    new_state.last_alert_sent = now
+    if webhook_url:
+        _post_slack(webhook_url, message)
+    return new_state, True
+
+
+def _handle_recovery_or_ok(
+    state: AlertState,
+    lookback: dt.timedelta,
+    now: dt.datetime,
+    webhook_url: str | None,
+) -> tuple[AlertState, bool]:
+    new_state = AlertState(status="available", last_alert_sent=now)
+    if state.status != "missing":
+        print(
+            f"LAADS data is available for all {lookback.days} days checked. No alert needed."
+        )
+        return new_state, False
+
+    message = (
+        f":white_check_mark: LAADS data has recovered. "
+        f"Data was missing since {state.missing_since or 'unknown'}."
+    )
+    print(message)
+    if webhook_url:
+        _post_slack(webhook_url, message)
+    return new_state, True
+
+
+def handler(event: dict, context: dict) -> dict:
+    """AWS Lambda handler."""
+    bucket = os.environ["LAADS_BUCKET"]
+    webhook_url: str | None = os.getenv("HLS_SLACK_ALERT_WEBHOOK") or None
+    ssm_path = os.environ["LAADS_ALERT_STATE_SSM_PATH"]
+    lookback = dt.timedelta(days=int(os.getenv("LAADS_LOOKBACK_DAYS", "14")))
+    alert_interval = dt.timedelta(
+        hours=int(os.getenv("LAADS_ALERT_INTERVAL_HOURS", "12"))
+    )
+    lag = dt.timedelta(hours=int(os.getenv("LAADS_LAG_HOURS", "30")))
+
+    missing_days = _check_recent_availability(bucket, lookback, lag)
+    state = _get_state(ssm_path)
+    now = dt.datetime.now(tz=dt.timezone.utc)
+
+    if missing_days:
+        new_state, alerted = _handle_outage(
+            state, missing_days, lookback, alert_interval, now, webhook_url
+        )
+    else:
+        new_state, alerted = _handle_recovery_or_ok(state, lookback, now, webhook_url)
+
+    _put_state(ssm_path, new_state)
+    return {
+        "missing_days": missing_days,
+        "previous_status": state.status,
+        "alerted": alerted,
+    }

--- a/lambda_functions/laads_available.py
+++ b/lambda_functions/laads_available.py
@@ -8,48 +8,13 @@ doy as yyyydoy
 landsat as LC08_L1TP_170071_20190303_20190309_01_T1
 sentinel as S2B_MSIL1C_20190301T075849_N0207_R035_T35HKD_20190301T121820
 """
+
 import os
-import re
-from datetime import date
-from typing import Dict
 
-import boto3
-from botocore.errorfactory import ClientError
-
-s3 = boto3.client("s3")
+from hls_lambda_layer.laads_utils import getyyyydoy, key_pattern_exists
 
 
-def key_pattern_exists(bucket: str, key_pattern: str):
-    try:
-        response = s3.list_objects_v2(Bucket=bucket, Prefix=key_pattern)
-        if "Contents" in response:
-            return True
-        else:
-            return False
-    except ClientError as e:
-        print(e)
-
-
-def getyyyydoy(date_str: str):
-    # Setup regular expressions for getting date
-    dmy = re.compile("(20[0-9][0-9])-?([0-9][0-9])-?([0-9][0-9])")
-    ydoy = re.compile("(20[0-9][0-9])-?([0-9][0-9][0-9])$")
-    matches = dmy.search(date_str)
-    if matches is not None:
-        year = int(matches[1])
-        month = int(matches[2])
-        day = int(matches[3])
-        d = date(year, month, day)
-        return d.strftime("%Y%j"), str(year)
-    else:
-        matches = ydoy.search(date_str)
-        year = matches[1]
-        doy = matches[2]
-        print(doy)
-        return f"{year}{doy}", str(year)
-
-
-def handler(event: Dict, context: Dict):
+def handler(event: dict, context: dict):
     """AWS Lambda handler."""
     # Get date from direct call or from query parameters via gateway call
 
@@ -63,25 +28,20 @@ def handler(event: Dict, context: Dict):
     bucket = os.getenv("LAADS_BUCKET", None)
     if bucket is None:
         raise Exception("No Bucket set")
+
     ydoy, year = getyyyydoy(date_str)
     vj_pattern = f"lasrc_aux/LADS/{year}/VJ104ANC.A{ydoy}"
-    print(f"------{bucket}    {vj_pattern} ------")
-    vj_exists = key_pattern_exists(bucket, vj_pattern)
     vnp_pattern = f"lasrc_aux/LADS/{year}/VNP04ANC.A{ydoy}"
-    vnp_exists = key_pattern_exists(bucket, vnp_pattern)
-    if vj_exists or vnp_exists:
-        exists = True
-    else:
-        exists = False
-    output = {
+    print(f"------{bucket}    {vj_pattern} ------")
+
+    available = key_pattern_exists(bucket, vj_pattern) or key_pattern_exists(
+        bucket, vnp_pattern
+    )
+    return {
         "granule": date_str,
         "year": year,
         "doy": ydoy,
         "bucket": bucket,
         "pattern": f"{vj_pattern} {vnp_pattern}",
-        "available": False,
+        "available": available,
     }
-    if exists:
-        output["available"] = True
-        return output
-    return output

--- a/lambda_functions/tests/test_laads_alert.py
+++ b/lambda_functions/tests/test_laads_alert.py
@@ -1,0 +1,200 @@
+import json
+import datetime as dt
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from lambda_functions.laads_alert import _check_recent_availability, handler
+
+
+BUCKET = "test-laads-bucket"
+SSM_PATH = "/test-stack/laads-alert-state"
+WEBHOOK = "https://hooks.slack.example.com/test"
+
+
+def _make_ssm_response(state: dict):
+    return {"Parameter": {"Value": json.dumps(state)}}
+
+
+def _iso_hours_ago(hours: float) -> str:
+    return (dt.datetime.now(tz=dt.timezone.utc) - dt.timedelta(hours=hours)).isoformat()
+
+
+@pytest.fixture
+def laads_env(monkeypatch):
+    monkeypatch.setenv("LAADS_BUCKET", BUCKET)
+    monkeypatch.setenv("LAADS_ALERT_STATE_SSM_PATH", SSM_PATH)
+    monkeypatch.setenv("LAADS_LOOKBACK_DAYS", "3")
+    monkeypatch.setenv("LAADS_ALERT_INTERVAL_HOURS", "12")
+    monkeypatch.setenv("LAADS_LAG_HOURS", "30")
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_all_available_no_prior_outage(mock_s3, mock_ssm, laads_env):
+    """All data present, SSM shows available → no Slack message."""
+    mock_s3.list_objects_v2.return_value = {"Contents": ["key"]}
+    mock_ssm.get_parameter.return_value = _make_ssm_response({"status": "available"})
+
+    result = handler({}, {})
+
+    assert result["missing_days"] == []
+    assert result["previous_status"] == "available"
+    assert result["alerted"] is False
+    saved = json.loads(mock_ssm.put_parameter.call_args[1]["Value"])
+    assert saved["status"] == "available"
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("lambda_functions.laads_alert._post_slack")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_missing_data_sends_alert(
+    mock_s3, mock_post_slack, mock_ssm, laads_env, monkeypatch
+):
+    """Data missing, no prior alert → Slack alert sent, SSM updated."""
+    monkeypatch.setenv("HLS_SLACK_ALERT_WEBHOOK", WEBHOOK)
+
+    mock_s3.list_objects_v2.return_value = {}
+    mock_ssm.get_parameter.return_value = _make_ssm_response({"status": "available"})
+
+    result = handler({}, {})
+
+    assert len(result["missing_days"]) == 3
+    assert result["alerted"] is True
+    mock_post_slack.assert_called_once()
+    assert "missing" in mock_post_slack.call_args[0][1].lower()
+
+    saved = json.loads(mock_ssm.put_parameter.call_args[1]["Value"])
+    assert saved["status"] == "missing"
+    assert "missing_since" in saved
+    assert "last_alert_sent" in saved
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("lambda_functions.laads_alert._post_slack")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_missing_alert_throttled(
+    mock_s3, mock_post_slack, mock_ssm, laads_env, monkeypatch
+):
+    """Data still missing, alert sent recently → throttled, no Slack call."""
+    monkeypatch.setenv("HLS_SLACK_ALERT_WEBHOOK", WEBHOOK)
+
+    mock_s3.list_objects_v2.return_value = {}
+    mock_ssm.get_parameter.return_value = _make_ssm_response(
+        {
+            "status": "missing",
+            "missing_since": "2026-04-13",
+            "last_alert_sent": _iso_hours_ago(1),  # sent 1 hour ago, interval is 12h
+        }
+    )
+
+    result = handler({}, {})
+
+    assert len(result["missing_days"]) == 3
+    assert result["alerted"] is False
+    mock_post_slack.assert_not_called()
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("lambda_functions.laads_alert._post_slack")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_missing_alert_fires_after_interval(
+    mock_s3, mock_post_slack, mock_ssm, laads_env, monkeypatch
+):
+    """Data still missing, last alert was >12h ago → alert fires again."""
+    monkeypatch.setenv("HLS_SLACK_ALERT_WEBHOOK", WEBHOOK)
+
+    mock_s3.list_objects_v2.return_value = {}
+    mock_ssm.get_parameter.return_value = _make_ssm_response(
+        {
+            "status": "missing",
+            "missing_since": "2026-04-13",
+            "last_alert_sent": _iso_hours_ago(13),  # sent 13 hours ago
+        }
+    )
+
+    result = handler({}, {})
+
+    assert result["alerted"] is True
+    mock_post_slack.assert_called_once()
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("lambda_functions.laads_alert._post_slack")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_recovery_sends_immediately(
+    mock_s3, mock_post_slack, mock_ssm, laads_env, monkeypatch
+):
+    """Data recovered after outage → Slack recovery alert sent immediately, ignores throttle."""
+    monkeypatch.setenv("HLS_SLACK_ALERT_WEBHOOK", WEBHOOK)
+
+    mock_s3.list_objects_v2.return_value = {"Contents": ["key"]}
+    mock_ssm.get_parameter.return_value = _make_ssm_response(
+        {
+            "status": "missing",
+            "missing_since": "2026-04-10",
+            "last_alert_sent": _iso_hours_ago(1),  # recent alert — recovery still fires
+        }
+    )
+
+    result = handler({}, {})
+
+    assert result["missing_days"] == []
+    assert result["previous_status"] == "missing"
+    assert result["alerted"] is True
+    mock_post_slack.assert_called_once()
+    assert "recovered" in mock_post_slack.call_args[0][1].lower()
+
+    saved = json.loads(mock_ssm.put_parameter.call_args[1]["Value"])
+    assert saved["status"] == "available"
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("lambda_functions.laads_alert._post_slack")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_no_webhook_skips_slack(mock_s3, mock_post_slack, mock_ssm, laads_env):
+    """Missing data but no webhook configured → no Slack call."""
+    mock_s3.list_objects_v2.return_value = {}
+    mock_ssm.get_parameter.return_value = _make_ssm_response({"status": "available"})
+
+    result = handler({}, {})
+
+    assert len(result["missing_days"]) == 3
+    mock_post_slack.assert_not_called()
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_lag_anchor_date(mock_s3, mock_ssm, laads_env):
+    """The most recent date checked respects the lag — not today's date."""
+    checked_dates = []
+
+    def fake_list(Bucket, Prefix):
+        checked_dates.append(Prefix)
+        return {"Contents": ["key"]}
+
+    mock_s3.list_objects_v2.side_effect = fake_list
+
+    _check_recent_availability(
+        BUCKET, lookback=dt.timedelta(days=3), lag=dt.timedelta(hours=30)
+    )
+
+    today_ydoy = dt.date.today().strftime("%Y%j")
+    assert not any(
+        today_ydoy in p for p in checked_dates
+    ), f"Today ({today_ydoy}) should not be checked due to lag; got {checked_dates}"
+
+
+@patch("lambda_functions.laads_alert.ssm")
+@patch("hls_lambda_layer.laads_utils.s3")
+def test_ssm_not_found_treated_as_available(mock_s3, mock_ssm, laads_env):
+    """SSM parameter missing on first run → treated as previously available."""
+    mock_s3.list_objects_v2.return_value = {"Contents": ["key"]}
+    error_response = {"Error": {"Code": "ParameterNotFound", "Message": "not found"}}
+    mock_ssm.get_parameter.side_effect = ClientError(error_response, "GetParameter")
+
+    result = handler({}, {})
+
+    assert result["previous_status"] == "available"
+    assert result["missing_days"] == []

--- a/lambda_functions/tests/test_laads_available.py
+++ b/lambda_functions/tests/test_laads_available.py
@@ -1,10 +1,9 @@
-import os
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
-from botocore.errorfactory import ClientError
 
-from lambda_functions.laads_available import getyyyydoy, handler
+from hls_lambda_layer.laads_utils import getyyyydoy
+from lambda_functions.laads_available import handler
 
 
 def test_getyyyydoy():
@@ -27,10 +26,12 @@ def test_handler_keyError():
         assert expected in str(e.value)
 
 
-@patch.dict(os.environ, {"LAADS_BUCKET": "test"})
-@patch("lambda_functions.laads_available.s3")
-def test_handler(s3):
-    from lambda_functions.laads_available import handler
+def test_handler(monkeypatch):
+    monkeypatch.setenv("LAADS_BUCKET", "test")
+
+    mock_s3 = MagicMock()
+    mock_s3.list_objects_v2.return_value = {"Contents": ["a key"]}
+    monkeypatch.setattr("hls_lambda_layer.laads_utils.s3", mock_s3)
 
     granule = "S2A_MSIL1C_20191001T201241_N0208_R028_T09WXT_20191001T220736A"
     event = {"granule": granule}
@@ -43,7 +44,4 @@ def test_handler(s3):
         "available": True,
     }
 
-    s3.list_objects_v2.return_value = {"Contents": ["a key"]}
-
-    response = handler(event, {})
-    assert response == expected
+    assert handler(event, {}) == expected

--- a/layers/hls_lambda_layer/python/hls_lambda_layer/laads_utils.py
+++ b/layers/hls_lambda_layer/python/hls_lambda_layer/laads_utils.py
@@ -1,0 +1,67 @@
+"""
+HLS: LaSRC LAADS Auxiliary Data utilities
+
+Shared helpers for checking whether LAADS auxiliary data is present in S3.
+Used by both the per-granule availability checker (laads_available Lambda)
+and the scheduled availability alerter (laads_alert Lambda).
+"""
+
+import re
+from datetime import date
+
+import boto3
+from botocore.exceptions import ClientError
+
+s3 = boto3.client("s3")
+
+_DMY_RE = re.compile("(20[0-9][0-9])-?([0-9][0-9])-?([0-9][0-9])")
+_YDOY_RE = re.compile("(20[0-9][0-9])-?([0-9][0-9][0-9])$")
+
+
+def getyyyydoy(date_str: str) -> tuple[str, str]:
+    """Parse a date string into (yyyydoy, year).
+
+    Accepts:
+      - yyyy-mm-dd
+      - yyyydoy
+      - Landsat scene ID  (LC08_L1TP_170071_20190303_...)
+      - Sentinel scene ID (S2B_MSIL1C_20190301T075849_...)
+    """
+    matches = _DMY_RE.search(date_str)
+    if matches is not None:
+        year = int(matches[1])
+        month = int(matches[2])
+        day = int(matches[3])
+        d = date(year, month, day)
+        return d.strftime("%Y%j"), str(year)
+    else:
+        matches = _YDOY_RE.search(date_str)
+        year = matches[1]
+        doy = matches[2]
+        return f"{year}{doy}", str(year)
+
+
+def key_pattern_exists(bucket: str, key_pattern: str) -> bool:
+    """Return True if any S3 objects exist under the given key prefix."""
+    try:
+        response = s3.list_objects_v2(Bucket=bucket, Prefix=key_pattern)
+        return "Contents" in response
+    except ClientError as e:
+        print(e)
+        return False
+
+
+def check_laads_for_date(bucket: str, date_str: str) -> tuple[bool, str]:
+    """Check whether LAADS auxiliary data exists in S3 for the given date.
+
+    Returns:
+        (available, ydoy) where available is True if either the VJ or VNP
+        auxiliary file prefix exists, and ydoy is the resolved year-doy string.
+    """
+    ydoy, year = getyyyydoy(date_str)
+    vj_pattern = f"lasrc_aux/LADS/{year}/VJ104ANC.A{ydoy}"
+    vnp_pattern = f"lasrc_aux/LADS/{year}/VNP04ANC.A{ydoy}"
+    available = key_pattern_exists(bucket, vj_pattern) or key_pattern_exists(
+        bucket, vnp_pattern
+    )
+    return available, ydoy

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -95,6 +95,12 @@ LANDSAT_SNS_TOPIC_ENABLED = (
     getenv("HLS_LANDSAT_SNS_TOPIC_ENABLED", "true").lower() == "true"
 )
 
+LAADS_ALERT_WEBHOOK = getenv("HLS_SLACK_ALERT_WEBHOOK", None)
+LAADS_ALERT_CHECK_CRON = getenv("HLS_LAADS_ALERT_CHECK_CRON", "cron(0/30 * * * ? *)")
+LAADS_LOOKBACK_DAYS = getenv("HLS_LAADS_LOOKBACK_DAYS", "14")
+LAADS_ALERT_INTERVAL_HOURS = getenv("HLS_LAADS_ALERT_INTERVAL_HOURS", "12")
+LAADS_LAG_HOURS = getenv("HLS_LAADS_LAG_HOURS", "30")
+
 DOWNLOADER_FUNCTION_ARN = getenv("HLS_DOWNLOADER_FUNCTION_ARN", None)
 LAADS_BUCKET_BOOTSTRAP = getenv(
     "HLS_LAADS_BUCKET_BOOTSTRAP", "hls-development-laads-bucket"
@@ -323,6 +329,24 @@ class HlsStack(Stack):
             code_file="laads_available.py",
             env={"LAADS_BUCKET": LAADS_BUCKET},
             timeout=120,
+            layers=[self.hls_lambda_layer],
+        )
+
+        self.laads_alert = Lambda(
+            self,
+            "LaadsAlert",
+            code_file="laads_alert.py",
+            env={
+                "LAADS_BUCKET": LAADS_BUCKET,
+                "HLS_SLACK_ALERT_WEBHOOK": LAADS_ALERT_WEBHOOK,
+                "LAADS_ALERT_STATE_SSM_PATH": f"/{STACKNAME}/laads-alert-state",
+                "LAADS_LOOKBACK_DAYS": LAADS_LOOKBACK_DAYS,
+                "LAADS_ALERT_INTERVAL_HOURS": LAADS_ALERT_INTERVAL_HOURS,
+                "LAADS_LAG_HOURS": LAADS_LAG_HOURS,
+            },
+            timeout=120,
+            layers=[self.hls_lambda_layer],
+            cron_str=LAADS_ALERT_CHECK_CRON,
         )
 
         self.check_twin_granule = Lambda(
@@ -1009,6 +1033,15 @@ class HlsStack(Stack):
         )
         self.laads_cron.function.add_to_role_policy(self.laads_bucket_read_policy)
         self.laads_available.function.add_to_role_policy(self.laads_bucket_read_policy)
+        self.laads_alert.function.add_to_role_policy(self.laads_bucket_read_policy)
+        self.laads_alert.function.add_to_role_policy(
+            aws_iam.PolicyStatement(
+                resources=[
+                    f"arn:aws:ssm:{self.region}:{self.account}:parameter/{STACKNAME}/laads-alert-state"
+                ],
+                actions=["ssm:GetParameter", "ssm:PutParameter"],
+            )
+        )
 
         if DOWNLOADER_FUNCTION_ARN:
             self.downloader_function = aws_lambda.Function.from_function_arn(


### PR DESCRIPTION
## Description

This PR closes https://github.com/NASA-IMPACT/hls_development/issues/363

Our most common HLS production outage is caused by LAADS data being unavailable, and this PR will help us learn about an outage ASAP. This is generally useful so we can inform downstream users and LPDAAC ASAP, but also useful so we can verify that it's not us causing the outage (e.g., did our auth token expire without someone renewing it?... a problem with an easy fix we can do in a separate PR)

## How I did it

- refactor the details about where LAADS data should live so our "is LAADS available?" Lambda and our alert are in sync
- setup the alert Lambda to check if data are missing over the last `<N>` days, factoring in a ~24 hour lag and a 6 (default) hour buffer period
- use the Slack webhook token configured in our repo secrets to post at most every 12 hours for a sustained outage
- setup a SSM parameter to indicate when we last alerted... this serves two roles,
    - it enables us to notify Slack when the LAADS outage is over
    - it allows us to perform the check (every 30 minutes) at a different frequency than our reporting cadence (every 12 hours)
