### PR TITLE
fix: don't schedule LAADS alert without webhook

### DIFF
--- a/stack/hlsconstructs/lambdafunc.py
+++ b/stack/hlsconstructs/lambdafunc.py
@@ -36,6 +36,8 @@ class Lambda(Construct):
         """Create AWS Lambda stack."""
         super().__init__(scope, id, **kwargs)
 
+        env = {k: v for k, v in env.items() if v is not None} if env else None
+
         if package_code_dir is not None:
             absolute_path = os.path.join(
                 os.path.dirname(__file__),

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -391,7 +391,7 @@ class HlsStack(Stack):
             },
             timeout=120,
             layers=[self.hls_lambda_layer],
-            cron_str=LAADS_ALERT_CHECK_CRON,
+            cron_str=LAADS_ALERT_CHECK_CRON if LAADS_ALERT_WEBHOOK else None,
         )
 
         self.check_twin_granule = Lambda(


### PR DESCRIPTION
This PR fixes the intended conditionality of the LAADS alert. If the Slack webhook doesn't exist, we don't want to send the alert (obviously). However this broke at the IAC level because we would pass a `None` to the Lambda function, which CDK doesn't permit.

To fix we do two changes,
1. Remove `None` values from the Lambda envvars as part of the construct
2. Avoid scheduling the Lambda in the first place if there's no webhook defined to send the alert

This is intended to avoid double-messaging from prod & dev environments when data are missing.