### PR TITLE
feat: enable switching between On Demand and Spot

### DIFF
--- a/stack/hlsconstructs/batch.py
+++ b/stack/hlsconstructs/batch.py
@@ -20,6 +20,7 @@ class Batch(Construct):
         ssh_keyname: str,
         efs: aws_efs.CfnFileSystem,
         use_cw: bool = True,
+        spot: bool = True,
         image_id: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -149,20 +150,38 @@ class Batch(Construct):
             )
         )
 
-        compute_resources = aws_batch.CfnComputeEnvironment.ComputeResourcesProperty(
-            #  allocation_strategy="BEST_FIT_PROGRESSIVE",
-            allocation_strategy="SPOT_CAPACITY_OPTIMIZED",
-            desiredv_cpus=0,
-            instance_role=ecs_instance_profile.ref,
-            instance_types=instance_types,
-            launch_template=launch_template_props,
-            maxv_cpus=maxv_cpus,
-            minv_cpus=0,
-            security_group_ids=[self.ecs_host_security_group.ref],
-            subnets=[s.subnet_id for s in network.public_subnets],
-            type="SPOT",
-            spot_iam_fleet_role=self.ecs_host_security_group.ref,
-        )
+        if spot:
+            compute_resources = (
+                aws_batch.CfnComputeEnvironment.ComputeResourcesProperty(
+                    allocation_strategy="SPOT_CAPACITY_OPTIMIZED",
+                    desiredv_cpus=0,
+                    instance_role=ecs_instance_profile.ref,
+                    instance_types=instance_types,
+                    launch_template=launch_template_props,
+                    maxv_cpus=maxv_cpus,
+                    minv_cpus=0,
+                    security_group_ids=[self.ecs_host_security_group.ref],
+                    subnets=[s.subnet_id for s in network.public_subnets],
+                    type="SPOT",
+                    spot_iam_fleet_role=self.ecs_host_security_group.ref,
+                )
+            )
+        else:
+            compute_resources = (
+                aws_batch.CfnComputeEnvironment.ComputeResourcesProperty(
+                    # SPOT_CAPACITY_OPTIMIZED is SPOT-only; EC2 uses BEST_FIT_*.
+                    allocation_strategy="BEST_FIT_PROGRESSIVE",
+                    desiredv_cpus=0,
+                    instance_role=ecs_instance_profile.ref,
+                    instance_types=instance_types,
+                    launch_template=launch_template_props,
+                    maxv_cpus=maxv_cpus,
+                    minv_cpus=0,
+                    security_group_ids=[self.ecs_host_security_group.ref],
+                    subnets=[s.subnet_id for s in network.public_subnets],
+                    type="EC2",
+                )
+            )
 
         compute_environment = aws_batch.CfnComputeEnvironment(
             self,

--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -67,6 +67,7 @@ class Rds(Construct):
             cluster_identifier=f"rds-{os.getenv('HLS_STACKNAME')}",
             serverless_v2_min_capacity=min_capacity,
             serverless_v2_max_capacity=max_capacity,
+            serverless_v2_auto_pause_duration=Duration.minutes(10) if min_capacity == 0 else None,
             writer=aws_rds.ClusterInstance.serverless_v2(
                 id="serverless-1",
                 instance_identifier=f"rds-{os.getenv('HLS_STACKNAME')}-serverless-1",
@@ -80,18 +81,6 @@ class Rds(Construct):
             security_groups=[self.security_group],
             removal_policy=RemovalPolicy.RETAIN,
         )
-
-        # Only set auto-pause if min_capacity is 0 as Aurora Serverless v2 doesn't
-        # support auto-pausing with >0 min capacity
-        if min_capacity == 0:
-            # CDK doesn't yet support "SecondsUntilAutoPause" but there is work in
-            # progress to add it,
-            #   issue: https://github.com/aws/aws-cdk/issues/32280
-            #   PR: https://github.com/aws/aws-cdk/pull/32787
-            self.database.node.default_child.add_property_override(
-                "ServerlessV2ScalingConfiguration.SecondsUntilAutoPause",
-                600,
-            )
 
         self.arn = self.database.cluster_arn
 

--- a/stack/hlsconstructs/rds.py
+++ b/stack/hlsconstructs/rds.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import RemovalPolicy, SecretValue, aws_ec2, aws_iam, aws_rds, aws_secretsmanager
+from aws_cdk import Duration, RemovalPolicy, SecretValue, aws_ec2, aws_iam, aws_rds, aws_secretsmanager
 from constructs import Construct
 from hlsconstructs.network import Network
 

--- a/stack/stack.py
+++ b/stack/stack.py
@@ -124,6 +124,10 @@ except ValueError:
 
 REPLACE_EXISTING = getenv("HLS_REPLACE_EXISTING", "true") == "true"
 USE_CLOUD_WATCH = getenv("HLS_USE_CLOUD_WATCH", "false") == "true"
+# Use SPOT instances (cheaper, interruptible) by default. Set to "false" to use
+# On-Demand instances, e.g. in a dev environment where experiment turnaround
+# time matters more than the SPOT cost savings.
+USE_SPOT = getenv("HLS_BATCH_SPOT", "true").lower() == "true"
 GCC = getenv("GCC", None) == "true"
 INSTRUMENT_SCIENCE_CONTAINER = (
     getenv("HLS_INSTRUMENT_SCIENCE_CONTAINER", "false") == "true"
@@ -290,6 +294,7 @@ class HlsStack(Stack):
             instance_types=["r5d"],
             ssh_keyname=SSH_KEYNAME,
             use_cw=USE_CLOUD_WATCH,
+            spot=USE_SPOT,
             image_id=image_id,
         )
 


### PR DESCRIPTION
We're running experiments in the "dev" environment and I'm suffering from having to re-re-rerun results to the point where we're spending more dev time managing experiments than we're saving with Spot.

This PR adds the `HLS_BATCH_SPOT` envvar (default - true) to disable Spot market instances and use On Demand. The intention is to switch to this when doing experimental work.